### PR TITLE
Detect Librera and redirect to feed.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ require_once dirname(__FILE__) . '/config.php';
 /** @var array $config */
 
 // If we detect that an OPDS reader try to connect try to redirect to feed.php
-if (preg_match('/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon\+ Reader|Chunky|AlReader|EBookDroid|BookReader|CoolReader|PageTurner|books\.ebook\.pdf\.reader|com\.hiwapps\.ebookreader|OpenBook)/', $_SERVER['HTTP_USER_AGENT'])) {
+if (preg_match('/(Librera|MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon\+ Reader|Chunky|AlReader|EBookDroid|BookReader|CoolReader|PageTurner|books\.ebook\.pdf\.reader|com\.hiwapps\.ebookreader|OpenBook)/', $_SERVER['HTTP_USER_AGENT'])) {
     header('location: ' . Config::ENDPOINT["feed"]);
     exit();
 }


### PR DESCRIPTION
Add Librera reader to detected OPDS compatible readers.

[Librera developer changed the user agent string so that it can be detected by COPS](https://github.com/foobnix/LibreraReader/issues/1128). This should be available soon on Play store version of Librera. Tested with Beta version of Librera.